### PR TITLE
Adds support for OAuth 2.0

### DIFF
--- a/ESI.NET/Enumerations/AuthVersionType.cs
+++ b/ESI.NET/Enumerations/AuthVersionType.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using System.Runtime.Serialization;
+
+namespace ESI.NET.Enumerations
+{
+    [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public enum AuthVersion
+    {
+        [EnumMember(Value = "v1")]  /**/ v1,
+        [EnumMember(Value = "v2")]  /**/ v2
+    }
+}

--- a/ESI.NET/EsiConfig.cs
+++ b/ESI.NET/EsiConfig.cs
@@ -10,5 +10,6 @@ namespace ESI.NET
         public string SecretKey { get; set; }
         public string CallbackUrl { get; set; }
         public string UserAgent { get; set; }
+        public AuthVersion AuthVersion { get; set; }
     }
 }

--- a/ESI.NET/Logic/_SSOLogic.cs
+++ b/ESI.NET/Logic/_SSOLogic.cs
@@ -27,11 +27,17 @@ namespace ESI.NET
 
             clientKey = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{config.ClientId}:{config.SecretKey}"));
 
-            oauthEndpoint = (_config.AuthVersion == AuthVersion.v1) ? "https://login.eveonline.com/oauth/" : "https://login.eveonline.com/v2/oauth/";
+            oauthEndpoint = (_config.AuthVersion == AuthVersion.v1) ? "https://login.eveonline.com/oauth" : "https://login.eveonline.com/v2/oauth";
         }
 
-        public string CreateAuthenticationUrl(List<string> scopes = null)
-            => $"{oauthEndpoint}/authorize/?response_type=code&redirect_uri={Uri.EscapeDataString(_config.CallbackUrl)}&client_id={_config.ClientId}{((scopes != null) ? $"&scope={string.Join(" ", scopes)}" : "")}";
+        /// <summary>
+        /// Generates the authentication URL that can be used to start the SSO workflow. 
+        /// </summary>
+        /// <param name="scopes"></param>
+        /// <param name="state">Required for Oauth 2.0, the state should be stored in a session and checked in the callback. If no state is provided it will be set to 0</param>
+        /// <returns></returns>
+        public string CreateAuthenticationUrl(List<string> scopes = null, string state = "0")
+            => $"{oauthEndpoint}/authorize/?response_type=code&redirect_uri={Uri.EscapeDataString(_config.CallbackUrl)}&client_id={_config.ClientId}{((scopes != null) ? $"&scope={string.Join(" ", scopes)}" : "")}&state={state}";
         
 
 

--- a/ESI.NET/Logic/_SSOLogic.cs
+++ b/ESI.NET/Logic/_SSOLogic.cs
@@ -77,7 +77,7 @@ namespace ESI.NET
         public async Task<AuthorizedCharacterData> Verify(SsoToken token)
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
-            var response = await _client.GetAsync($"{oauthEndpoint}/verify").Result.Content.ReadAsStringAsync();
+            var response = await _client.GetAsync($"https://login.eveonline.com/oauth/verify").Result.Content.ReadAsStringAsync();
             var authorizedCharacter = JsonConvert.DeserializeObject<AuthorizedCharacterData>(response);
             authorizedCharacter.Token = token.AccessToken;
             authorizedCharacter.RefreshToken = token.RefreshToken;

--- a/ESI.NET/Logic/_SSOLogic.cs
+++ b/ESI.NET/Logic/_SSOLogic.cs
@@ -27,7 +27,7 @@ namespace ESI.NET
 
             clientKey = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{config.ClientId}:{config.SecretKey}"));
 
-            oauthEndpoint = (_config.AuthVersion == AuthVersion.v1) ? "https://login.eveonline.com/oauth" : "https://login.eveonline.com/v2/oauth";
+            oauthEndpoint = (_config.AuthVersion != AuthVersion.v2) ? "https://login.eveonline.com/oauth" : "https://login.eveonline.com/v2/oauth";
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -81,10 +81,12 @@ EsiResponse response = _client.Universe.Names(new List<long>()
 ## SSO Example
 
 ### SSO Login URL generator
-ESI.NET has a helper method to generate the URL required to authenticate a character or authorize roles (by providing a List<string> of scopes) for the Eve Online SSO.
+ESI.NET has a helper method to generate the URL required to authenticate a character or authorize roles (by providing a List<string> of scopes) for the Eve Online SSO. 
 ```cs
 var url = _client.SSO.CreateAuthenticationUrl();
 ```
+__SCOPE:__ As per the [OAuth 2.0 docs](https://docs.esi.evetech.net/docs/sso/web_based_sso_flow.html) a scope is required in the authentication url. The helper method takes an optional string parameter called __scope__. If you do not provide a scope the helper will place 0 at the end. _[Auth0 Docs - State Parameter](https://auth0.com/docs/protocols/oauth2/oauth-state)_.
+
 
 ### Initial SSO Token Request
 ```cs


### PR DESCRIPTION
Adds support for [Oauth 2.0](https://docs.esi.evetech.net/docs/sso/web_based_sso_flow.html). To use v2 set  AuthVersion.v2 in the configuration.

_See: https://github.com/seraphx2/ESI.NET/issues/23#issuecomment-495077911_
```CS
IOptions<EsiConfig> config = Options.Create(new EsiConfig()
{
    EsiUrl = "https://esi.evetech.net/",
    DataSource = DataSource.Tranquility,
    ClientId = "**********",
    SecretKey = "**********",
    CallbackUrl = "",
    UserAgent = "",
    AuthVersion = AuthVersion.v2
});

EsiClient client = new EsiClient(config);```