### PR TITLE
Fix duplicate scopes in authentication URL

### DIFF
--- a/ESI.NET/Logic/_SSOLogic.cs
+++ b/ESI.NET/Logic/_SSOLogic.cs
@@ -46,7 +46,7 @@ namespace ESI.NET
                     break;
             }
 
-            return $"{_ssoUrl}{authVersion}/oauth/authorize/?response_type=code&redirect_uri={Uri.EscapeDataString(_config.CallbackUrl)}&client_id={_config.ClientId}{((scopes != null) ? $"&scope={string.Join(" ", scopes)}" : "")}{((scopes != null) ? $"&scope={string.Join(" ", scopes)}" : "")}{((state != null) ? $"&state={state}" : "")}";
+            return $"{_ssoUrl}{authVersion}/oauth/authorize/?response_type=code&redirect_uri={Uri.EscapeDataString(_config.CallbackUrl)}&client_id={_config.ClientId}{((scopes != null) ? $"&scope={string.Join(" ", scopes)}" : "")}{((state != null) ? $"&state={state}" : "")}";
         }
 
         /// <summary>


### PR DESCRIPTION
Commit c3e20cc9caa626b875b0161f09d8e07474671795 introduced a bug where each scope would be duplicated in the authentication URL. EVE SSO fails when specifying scopes in this way.