### PR TITLE
Added inheritance to EsiClient constructor without IOptions and removed unused config property EsiConfig.AuthVersion

### DIFF
--- a/ESI.NET/EsiClient.cs
+++ b/ESI.NET/EsiClient.cs
@@ -17,9 +17,15 @@ namespace ESI.NET
         /// 
         /// </summary>
         /// <param name="config"></param>
-        public EsiClient(IOptions<EsiConfig> _config)
+        public EsiClient(IOptions<EsiConfig> _config) : this(_config.Value) { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="config"></param>
+        public EsiClient(EsiConfig _config)
         {
-            config = _config.Value;
+            config = _config;
             client = new HttpClient(new HttpClientHandler
             {
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate

--- a/README.md
+++ b/README.md
@@ -52,16 +52,15 @@ public ApiTestController(IEsiClient client) { _client = client; }
 If you are using a .NET Standard-compatible .NET Framework application, you can instantiate the client in this manner:
 
 ```cs
-IOptions<EsiConfig> config = Options.Create(new EsiConfig()
+EsiConfig config = new EsiConfig()
 {
     EsiUrl = "https://esi.evetech.net/",
     DataSource = DataSource.Tranquility,
     ClientId = "**********",
     SecretKey = "**********",
     CallbackUrl = "",
-    UserAgent = "",
-    AuthVersion = AuthVersion.v2
-});
+    UserAgent = ""
+};
 
 EsiClient client = new EsiClient(config);
 ```


### PR DESCRIPTION
No needs to create IOptions interface in .NET where there is no dependency injection, this creates unnecessary dependencies. This can be done through inheritance without using Options.Create(). 

Also removed from README.md unused config property EsiConfig.AuthVersion, previously deleted on source code