### PR TITLE
DynamicItem now has a proper data structure

### DIFF
--- a/ESI.NET/Logic/DogmaLogic.cs
+++ b/ESI.NET/Logic/DogmaLogic.cs
@@ -25,8 +25,8 @@ namespace ESI.NET.Logic
         /// </summary>
         /// <param name="attribute_id"></param>
         /// <returns></returns>
-        public async Task<EsiResponse<Attribute>> Attribute(int attribute_id)
-            => await Execute<Attribute>(_client, _config, RequestSecurity.Public, HttpMethod.Get, "/dogma/attributes/{attribute_id}/",
+        public async Task<EsiResponse<AttributeInfo>> Attribute(int attribute_id)
+            => await Execute<AttributeInfo>(_client, _config, RequestSecurity.Public, HttpMethod.Get, "/dogma/attributes/{attribute_id}/",
                 replacements: new Dictionary<string, string>()
                 {
                     { "attribute_id", attribute_id.ToString() }
@@ -44,8 +44,8 @@ namespace ESI.NET.Logic
         /// </summary>
         /// <param name="effect_id"></param>
         /// <returns></returns>
-        public async Task<EsiResponse<Effect>> Effect(int effect_id)
-            => await Execute<Effect>(_client, _config, RequestSecurity.Public, HttpMethod.Get, "/dogma/effects/{effect_id}/",
+        public async Task<EsiResponse<EffectInfo>> Effect(int effect_id)
+            => await Execute<EffectInfo>(_client, _config, RequestSecurity.Public, HttpMethod.Get, "/dogma/effects/{effect_id}/",
                 replacements: new Dictionary<string, string>()
                 {
                     { "effect_id", effect_id.ToString() }
@@ -57,8 +57,8 @@ namespace ESI.NET.Logic
         /// <param name="type_id"></param>
         /// <param name="item_id"></param>
         /// <returns></returns>
-        public async Task<EsiResponse<Effect>> DynamicItem(int type_id, long item_id)
-            => await Execute<Effect>(_client, _config, RequestSecurity.Public, HttpMethod.Get, "/dogma/dynamic/items/{type_id}/{item_id}/",
+        public async Task<EsiResponse<DynamicItem>> DynamicItem(int type_id, long item_id)
+            => await Execute<DynamicItem>(_client, _config, RequestSecurity.Public, HttpMethod.Get, "/dogma/dynamic/items/{type_id}/{item_id}/",
                 replacements: new Dictionary<string, string>()
                 {
                     { "type_id", type_id.ToString() },

--- a/ESI.NET/Models/Dogma/Attribute.cs
+++ b/ESI.NET/Models/Dogma/Attribute.cs
@@ -1,42 +1,15 @@
 ﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace ESI.NET.Models.Dogma
 {
     public class Attribute
     {
-        [JsonProperty("attribute_id")]
+        [JsonProperty("attribute_id", Required = Required.Always)]
         public int AttributeId { get; set; }
 
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
-        [JsonProperty("description")]
-        public string Description { get; set; }
-
-        [JsonProperty("icon_id")]
-        public int IconId { get; set; }
-
-        [JsonProperty("default_value")]
-        public double DefaultValue { get; set; }
-
-        [JsonProperty("published")]
-        public bool Published { get; set; }
-
-        [JsonProperty("display_name")]
-        public string DisplayName { get; set; }
-
-        [JsonProperty("unit_id")]
-        public int UnitId { get; set; }
-
-        [JsonProperty("stackable")]
-        public bool Stackable { get; set; }
-
-        [JsonProperty("high_is_good")]
-        public bool HighIsGood { get; set; }
-
-        /// <summary>
-        /// Only populated when used in DynamicItem; all other properties except AttributeId will be empty
-        /// </summary>
         [JsonProperty("value")]
         public decimal Value { get; set; }
     }

--- a/ESI.NET/Models/Dogma/AttributeInfo.cs
+++ b/ESI.NET/Models/Dogma/AttributeInfo.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+
+namespace ESI.NET.Models.Dogma
+{
+    public class AttributeInfo : Attribute
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("icon_id")]
+        public int IconId { get; set; }
+
+        [JsonProperty("default_value")]
+        public double DefaultValue { get; set; }
+
+        [JsonProperty("published")]
+        public bool Published { get; set; }
+
+        [JsonProperty("display_name")]
+        public string DisplayName { get; set; }
+
+        [JsonProperty("unit_id")]
+        public int UnitId { get; set; }
+
+        [JsonProperty("stackable")]
+        public bool Stackable { get; set; }
+
+        [JsonProperty("high_is_good")]
+        public bool HighIsGood { get; set; }
+    }
+}

--- a/ESI.NET/Models/Dogma/DynamicItem.cs
+++ b/ESI.NET/Models/Dogma/DynamicItem.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace ESI.NET.Models.Dogma
 {
-    class DynamicItem
+    public class DynamicItem
     {
         [JsonProperty("created_by")]
         public int CreatedBy { get; set; }

--- a/ESI.NET/Models/Dogma/Effect.cs
+++ b/ESI.NET/Models/Dogma/Effect.cs
@@ -1,98 +1,16 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace ESI.NET.Models.Dogma
 {
     public class Effect
     {
-        [JsonProperty("effect_id")]
+        [JsonProperty("effect_id", Required = Required.Always)]
         public int EffectId { get; set; }
 
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
-        [JsonProperty("display_name")]
-        public string DisplayName { get; set; }
-
-        [JsonProperty("description")]
-        public string Description { get; set; }
-
-        [JsonProperty("icon_id")]
-        public int IconId { get; set; }
-
-        [JsonProperty("effect_category")]
-        public int EffectCategory { get; set; }
-
-        [JsonProperty("pre_expression")]
-        public int PreExpression { get; set; }
-
-        [JsonProperty("post_expression")]
-        public int PostExpression { get; set; }
-
-        [JsonProperty("is_offensive")]
-        public bool IsOffensive { get; set; }
-
-        [JsonProperty("is_assistance")]
-        public bool IsAssistance { get; set; }
-
-        [JsonProperty("disallow_auto_repeat")]
-        public bool DisallowAutoRepeat { get; set; }
-
-        [JsonProperty("published")]
-        public bool Published { get; set; }
-
-        [JsonProperty("is_warp_safe")]
-        public bool IsWarpSafe { get; set; }
-
-        [JsonProperty("range_chance")]
-        public bool RangeChance { get; set; }
-
-        [JsonProperty("electronic_chance")]
-        public bool ElectronicChance { get; set; }
-
-        [JsonProperty("duration_attribute_id")]
-        public int DurationAttributeId { get; set; }
-
-        [JsonProperty("tracking_speed_attribute_id")]
-        public int TrackingSpeedAttributeId { get; set; }
-
-        [JsonProperty("discharge_attribute_id")]
-        public int DischargeAttributeId { get; set; }
-
-        [JsonProperty("range_attribute_id")]
-        public int RangeAttributeId { get; set; }
-
-        [JsonProperty("falloff_attribute_id")]
-        public int FalloffAttributeId { get; set; }
-
-        [JsonProperty("modifiers")]
-        public List<Modifier> Modifiers { get; set; } = new List<Modifier>();
-
-        /// <summary>
-        /// Only populated when used in DynamicItem; all other properties except EffectId will be empty
-        /// </summary>
         [JsonProperty("is_default")]
         public bool IsDefault { get; set; }
-    }
-
-    public class Modifier
-    {
-        [JsonProperty("func")]
-        public string Func { get; set; }
-
-        [JsonProperty("domain")]
-        public string Domain { get; set; }
-
-        [JsonProperty("modified_attribute_id")]
-        public int ModifiedAttributeId { get; set; }
-
-        [JsonProperty("modifying_attribute_id")]
-        public int ModifyingAttributeId { get; set; }
-
-        [JsonProperty("effect_id")]
-        public int EffectId { get; set; }
-
-        [JsonProperty("operator")]
-        public int Operator { get; set; }
     }
 }

--- a/ESI.NET/Models/Dogma/EffectInfo.cs
+++ b/ESI.NET/Models/Dogma/EffectInfo.cs
@@ -1,0 +1,89 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace ESI.NET.Models.Dogma
+{
+    public class EffectInfo : Effect
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("display_name")]
+        public string DisplayName { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("icon_id")]
+        public int IconId { get; set; }
+
+        [JsonProperty("effect_category")]
+        public int EffectCategory { get; set; }
+
+        [JsonProperty("pre_expression")]
+        public int PreExpression { get; set; }
+
+        [JsonProperty("post_expression")]
+        public int PostExpression { get; set; }
+
+        [JsonProperty("is_offensive")]
+        public bool IsOffensive { get; set; }
+
+        [JsonProperty("is_assistance")]
+        public bool IsAssistance { get; set; }
+
+        [JsonProperty("disallow_auto_repeat")]
+        public bool DisallowAutoRepeat { get; set; }
+
+        [JsonProperty("published")]
+        public bool Published { get; set; }
+
+        [JsonProperty("is_warp_safe")]
+        public bool IsWarpSafe { get; set; }
+
+        [JsonProperty("range_chance")]
+        public bool RangeChance { get; set; }
+
+        [JsonProperty("electronic_chance")]
+        public bool ElectronicChance { get; set; }
+
+        [JsonProperty("duration_attribute_id")]
+        public int DurationAttributeId { get; set; }
+
+        [JsonProperty("tracking_speed_attribute_id")]
+        public int TrackingSpeedAttributeId { get; set; }
+
+        [JsonProperty("discharge_attribute_id")]
+        public int DischargeAttributeId { get; set; }
+
+        [JsonProperty("range_attribute_id")]
+        public int RangeAttributeId { get; set; }
+
+        [JsonProperty("falloff_attribute_id")]
+        public int FalloffAttributeId { get; set; }
+
+        [JsonProperty("modifiers")]
+        public List<Modifier> Modifiers { get; set; } = new List<Modifier>();
+    }
+
+    public class Modifier
+    {
+        [JsonProperty("func")]
+        public string Func { get; set; }
+
+        [JsonProperty("domain")]
+        public string Domain { get; set; }
+
+        [JsonProperty("modified_attribute_id")]
+        public int ModifiedAttributeId { get; set; }
+
+        [JsonProperty("modifying_attribute_id")]
+        public int ModifyingAttributeId { get; set; }
+
+        [JsonProperty("effect_id")]
+        public int EffectId { get; set; }
+
+        [JsonProperty("operator")]
+        public int Operator { get; set; }
+    }
+}


### PR DESCRIPTION
We either make multiple requests to fetch all the fields, keep those not provided as default/null, or separate the types. 
Better ideas anyone?