### PR TITLE
fix for JWT issuer validation change 

### DIFF
--- a/ESI.NET/Logic/_SSOLogic.cs
+++ b/ESI.NET/Logic/_SSOLogic.cs
@@ -188,7 +188,7 @@ namespace ESI.NET
                 {
                     ValidateAudience = false,
                     ValidateIssuer = true,
-                    ValidIssuer = _ssoUrl,
+                    ValidIssuer = $"https://{_ssoUrl}",
                     ValidateIssuerSigningKey = true,
                     IssuerSigningKey = jwk,
                     ClockSkew = TimeSpan.FromSeconds(2), // CCP's servers seem slightly ahead (~1s)


### PR DESCRIPTION
login.eveonline.com -> https://login.eveonline.com

Fix for https://github.com/seraphx2/ESI.NET/issues/71