### PR TITLE
IEsiTokenRefreshSink.OnRefreshFailedAsync (missed by the previous release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,9 +161,14 @@ cancellation, pagination) is passed. **Every consumer needs code changes** — s
   surfaced two ways, and both fire:
   - `IEsiTokenRefreshSink` — implement it, register one
     (`services.AddScoped<IEsiTokenRefreshSink, YourSink>()`), and it covers every
-    authenticated call. This is the DI-friendly "persist once" hook.
+    authenticated call. This is the DI-friendly "persist once" hook. It also
+    carries `OnRefreshFailedAsync(character, exception)`, called when the
+    refresh token itself is rejected (revoked/expired/rescoped) — the triggering
+    call still throws, but this is where you'd flag the character so other jobs
+    stop querying it until it's re-authorized.
   - `EsiCallOptions.OnTokenRefreshed` — a per-call `Func<AuthorizedCharacterData, Task>`
-    for one-offs or non-DI use.
+    for one-offs or non-DI use. There's no per-call failure equivalent: a
+    one-off caller already gets the exception directly.
 - `EsiErrorLimitHandler` — reads `X-Esi-Error-Limit-*` and blocks further sends
   on the client until the window resets; throws `EsiErrorLimitException` on
   `420`. Wired by `AddEsi`.

--- a/ESI.NET/Http/EsiTokenRefreshHandler.cs
+++ b/ESI.NET/Http/EsiTokenRefreshHandler.cs
@@ -15,7 +15,9 @@ namespace ESI.NET.Http
     /// <see cref="EsiRequest"/>.Execute); after a refresh the request's bearer header is swapped,
     /// the per-call callback runs, and — when a DI scope is available — a registered
     /// <see cref="IEsiTokenRefreshSink"/> is invoked so the rotated refresh token can be persisted
-    /// once, centrally.
+    /// once, centrally. If the refresh itself throws, the registered sink's
+    /// <see cref="IEsiTokenRefreshSink.OnRefreshFailedAsync"/> is invoked instead (still only when a
+    /// DI scope is available) and the exception is rethrown — the triggering call fails either way.
     /// </summary>
     public sealed class EsiTokenRefreshHandler : DelegatingHandler
     {
@@ -43,7 +45,24 @@ namespace ESI.NET.Http
                 && character.ExpiresOn != default
                 && character.ExpiresOn <= DateTime.UtcNow.Add(Skew))
             {
-                await SsoLogic.RefreshAccessTokenAsync((r, ct) => base.SendAsync(r, ct), _config, character, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await SsoLogic.RefreshAccessTokenAsync((r, ct) => base.SendAsync(r, ct), _config, character, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    if (_scopeFactory != null)
+                    {
+                        using (var scope = _scopeFactory.CreateScope())
+                        {
+                            var failureSink = scope.ServiceProvider.GetService<IEsiTokenRefreshSink>();
+                            if (failureSink != null)
+                                await failureSink.OnRefreshFailedAsync(character, ex).ConfigureAwait(false);
+                        }
+                    }
+
+                    throw;
+                }
 
                 // the request was built with the stale token
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", character.Token);

--- a/ESI.NET/Http/IEsiTokenRefreshSink.cs
+++ b/ESI.NET/Http/IEsiTokenRefreshSink.cs
@@ -1,4 +1,5 @@
 ﻿using ESI.NET.Models.SSO;
+using System;
 using System.Threading.Tasks;
 
 namespace ESI.NET.Http
@@ -16,5 +17,13 @@ namespace ESI.NET.Http
         /// <c>RefreshToken</c> and <c>ExpiresOn</c> already updated in place.
         /// </summary>
         Task OnRefreshedAsync(AuthorizedCharacterData character);
+
+        /// <summary>
+        /// Called when a refresh attempt itself throws (the refresh token was revoked, expired, or
+        /// scopes changed). <paramref name="character"/> is unchanged from before the attempt.
+        /// The triggering call still fails — this is fired just before that exception propagates —
+        /// so use it to react (e.g. flag the character as needing re-authorization), not to recover.
+        /// </summary>
+        Task OnRefreshFailedAsync(AuthorizedCharacterData character, Exception exception);
     }
 }

--- a/README.md
+++ b/README.md
@@ -182,7 +182,11 @@ An authenticated call whose access token is within a minute of expiry is
 refreshed automatically before the request goes out, and `authChar` is updated in
 place. **EVE rotates the refresh token, so you must persist the new value.**
 
-Handle that once, for every call, with an `IEsiTokenRefreshSink`:
+Handle that once, for every call, with an `IEsiTokenRefreshSink`. The interface
+also has an `OnRefreshFailedAsync`, called when the refresh token itself is no
+longer good (revoked, expired, or the app's scopes changed) — the request still
+fails, but this is your one place to notice *why* and flag the character before
+some other background job wastes a call on it:
 
 ```csharp
 public class DbTokenSink : IEsiTokenRefreshSink
@@ -195,11 +199,26 @@ public class DbTokenSink : IEsiTokenRefreshSink
         _db.Characters.Update(c);
         await _db.SaveChangesAsync();
     }
+
+    // Refresh token was rejected - stop other jobs from querying this character
+    // until it's re-authorized.
+    public async Task OnRefreshFailedAsync(AuthorizedCharacterData c, Exception ex)
+    {
+        await _db.Characters
+            .Where(x => x.CharacterId == c.CharacterID)
+            .ExecuteUpdateAsync(x => x.SetProperty(row => row.CanQueryEsi, false));
+    }
 }
 
 services.AddScoped<IEsiTokenRefreshSink, DbTokenSink>();
 services.AddEsi(builder.Configuration.GetSection("EsiConfig"));
 ```
+
+`OnRefreshFailedAsync` fires just before the triggering call's exception
+propagates, so it's for reacting (flag it, log it, alert on it), not recovering
+— the call in flight still throws either way. It has no per-call
+`EsiCallOptions` equivalent: a one-off caller already gets the exception
+directly from the failed call, so there's nothing to add there.
 
 The handler resolves the sink in a fresh scope each time it fires, so a scoped
 `DbContext` is safe. For one-offs or non-DI code, set `OnTokenRefreshed` on the

--- a/tests/ESI.NET.Tests/TokenRefreshTests.cs
+++ b/tests/ESI.NET.Tests/TokenRefreshTests.cs
@@ -24,18 +24,26 @@ namespace ESI.NET.Tests
         private const string NewTokenJson =
             @"{ ""access_token"": ""NEW-ACCESS"", ""token_type"": ""Bearer"", ""expires_in"": 1200, ""refresh_token"": ""NEW-REFRESH"" }";
 
+        private const string InvalidGrantJson = @"{ ""error"": ""invalid_grant"", ""error_description"": ""The refresh token is invalid or expired."" }";
+
         private sealed class RoutingHandler : HttpMessageHandler
         {
             public HttpRequestMessage LastApiRequest;
             public int TokenCalls;
             public string ApiBody = "{}";
 
+            /// <summary>When set, the token endpoint returns this instead of a fresh token — simulates EVE rejecting the refresh (revoked/expired/rescoped).</summary>
+            public HttpStatusCode? TokenFailureStatus;
+            public string TokenFailureBody = InvalidGrantJson;
+
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 if (request.RequestUri.AbsolutePath == "/v2/oauth/token")
                 {
                     TokenCalls++;
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(NewTokenJson) });
+                    return Task.FromResult(TokenFailureStatus.HasValue
+                        ? new HttpResponseMessage(TokenFailureStatus.Value) { Content = new StringContent(TokenFailureBody) }
+                        : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(NewTokenJson) });
                 }
 
                 LastApiRequest = request;
@@ -46,7 +54,10 @@ namespace ESI.NET.Tests
         private sealed class FakeSink : IEsiTokenRefreshSink
         {
             public AuthorizedCharacterData Received;
+            public AuthorizedCharacterData FailedCharacter;
+            public Exception FailedException;
             public Task OnRefreshedAsync(AuthorizedCharacterData character) { Received = character; return Task.CompletedTask; }
+            public Task OnRefreshFailedAsync(AuthorizedCharacterData character, Exception exception) { FailedCharacter = character; FailedException = exception; return Task.CompletedTask; }
         }
 
         private static readonly EsiConfig Config = new EsiConfig
@@ -136,6 +147,24 @@ namespace ESI.NET.Tests
             await SendThrough(handler, routing, AuthedRequest(character));
 
             Assert.Same(character, sink.Received);
+        }
+
+        [Fact]
+        public async Task Failed_refresh_notifies_the_sink_and_still_throws()
+        {
+            var sink = new FakeSink();
+            var provider = new ServiceCollection().AddSingleton<IEsiTokenRefreshSink>(sink).BuildServiceProvider();
+            var routing = new RoutingHandler { TokenFailureStatus = HttpStatusCode.BadRequest };
+            var character = Character(DateTime.UtcNow.AddMinutes(-5));
+            var handler = new EsiTokenRefreshHandler(Options.Create(Config), provider.GetRequiredService<IServiceScopeFactory>());
+
+            await Assert.ThrowsAsync<ArgumentException>(() => SendThrough(handler, routing, AuthedRequest(character)));
+
+            Assert.Same(character, sink.FailedCharacter);
+            Assert.NotNull(sink.FailedException);
+            Assert.Null(sink.Received); // OnRefreshedAsync must not fire on a failed refresh
+            Assert.Equal("OLD-ACCESS", character.Token); // unchanged - the failed exchange never got to mutate it
+            Assert.Equal("OLD-REFRESH", character.RefreshToken);
         }
 
         [Fact]


### PR DESCRIPTION
Follow-up to the release just cut (`2026.912.1`). PR #84 added `IEsiTokenRefreshSink.OnRefreshFailedAsync` earlier tonight but was never actually merged into `dev` — it sat open, and its content shipped in neither `dev` nor `2026.912.1`. Found while investigating why that PR's SonarCloud check was showing failed (the scan itself was erroring out, unrelated to this).

Cherry-picked PR #84's commit directly onto current `dev` (a plain merge would've conflicted across most of the Logic files, since `dev` had moved substantially further through this same session's CA1305/CA1707/CA1062/net10.0 work) and verified:
- Builds clean, 0 analyzer warnings in the library
- 57/57 unit tests passing on both `net8.0` and `net10.0` (56 + the new failure-path test)

PR #84 is closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)